### PR TITLE
Removed hirak/prestissimo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,7 @@ RUN docker-php-source extract \
 # Install composer
 RUN php -r "readfile('https://getcomposer.org/installer');" | php && \
    mv composer.phar /usr/bin/composer && \
-   chmod +x /usr/bin/composer && \
-   composer global require hirak/prestissimo --no-scripts --no-progress --prefer-dist --optimize-autoloader --no-interaction --no-ansi
-
+   chmod +x /usr/bin/composer
 # Env variables
 ENV COMPOSER_CACHE_DIR=/dev/null
 


### PR DESCRIPTION
Removed hirak/prestissimo  because it leads to an exception mkdir(): Not a directory when running composer install after installing this package